### PR TITLE
Ignore camelcasing in destructuring and UNSAFE_* methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ module.exports = {
 		'arrow-spacing': 'error',
 		'block-spacing': 'error',
 		'brace-style': 'error',
-		'camelcase': ['error', { properties: 'never' }],
+		'camelcase': ['error', {
+			properties: 'never',
+			ignoreDestructuring: true,
+			allow: ['^UNSAFE_'],
+		}],
 		'comma-dangle': ['error', 'always-multiline'],
 		'comma-spacing': 'error',
 		'comma-style': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-chronograph",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-chronograph",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Base shared eslint configuration for Chronograph.",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
There is an argument that snake casing should be allowed when destructuring objects that interface with Rails (and hence use snake casing), e.g.

Currently, this:

```javascript
const { company_id, fund_id } = investment
```

would have to become:

```javascript
const { company_id: companyId, fund_id: fundId } = investment
```

I personally feel like this is desirable where `companyId` is going to be used throughout a module as a standalone variable, but not when it's simply going to used to create another object, e.g.:

```javascript
const newInvestment = { company_id, fund_id }
```

Thankfully, the ESLint `camelcase` rule has an [`ignoreDestructuring` argument](https://eslint.org/docs/rules/camelcase#ignoredestructuring-true) that allows precisely this use case.

This also adds the various React-deprecated `UNSAFE_*` methods to the list of variables to ignore.