### PR TITLE
upgrade react-hooks-plugin to v4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eslint": "^5.16.0",
         "eslint-plugin-import": "^2.17.2",
         "eslint-plugin-jest": "^22.5.1",
-        "eslint-plugin-react-hooks": "^4.0.5"
+        "eslint-plugin-react-hooks": "^4.5.0"
       },
       "peerDependencies": {
         "babel-eslint": "^10.0.1",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "engines": {
         "node": ">=10"
       },
@@ -2212,9 +2212,9 @@
       "requires": {}
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-jest": "^22.5.1",
-    "eslint-plugin-react-hooks": "^4.0.5"
+    "eslint-plugin-react-hooks": "^4.5.0"
   },
   "bugs": {
     "url": "https://github.com/chronograph-pe/chronograph/issues"


### PR DESCRIPTION
The current version of `react-hooks-plugin` has a bug where files with many conditionals are occasionally flagged as calling hooks conditionally. This frequently presents itself in the `MetricDefEditorSidePanel` component:
![image](https://github.com/chronograph-pe/eslint-config-chronograph/assets/118760036/2f3fd892-ac3e-48e1-b351-e74c839f0b0e)

More details on the bug here: https://github.com/facebook/react/issues/21328

This PR updates to v4.5.0 which should fix the bug.

Steps to verify:
- switch to the `eslint-config-chronograph` repo
- `npm install`
- set `name` attribute in `package.json` to `"eslint-config-chronograph"` instead of `"@chronograph-pe/eslint-config-chronograph"`. This is to match the package name in `cg-web`so that symlinking can work.
- run `npm link`
- switch to `cg-weg`
- run `npm link eslint-config-chronograph`
- `npm run lint` should work as expected